### PR TITLE
Migrate to AudioNimbus 0.12.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,12 +334,11 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc44eca573e79772966e324839246dc0639a893217e435f6e63f69902284e71"
+version = "0.12.0"
 dependencies = [
- "audionimbus-sys",
- "bitflags 2.11.0",
+ "audionimbus-sys 4.8.1",
+ "bitflags 2.10.0",
+ "slotmap",
 ]
 
 [[package]]
@@ -347,6 +346,13 @@ name = "audionimbus-sys"
 version = "4.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111aaefa0bd5af1de99eae6baff76fd3a98bee1d458fc23cc6c3da4a284e8722"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "audionimbus-sys"
+version = "4.8.1"
 dependencies = [
  "bindgen",
  "zip",
@@ -1528,7 +1534,7 @@ name = "bevy_steam_audio"
 version = "0.3.0-rc.1"
 dependencies = [
  "audionimbus",
- "audionimbus-sys",
+ "audionimbus-sys 4.8.0",
  "bevy_app",
  "bevy_asset",
  "bevy_camera",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,19 +334,13 @@ dependencies = [
 
 [[package]]
 name = "audionimbus"
-version = "0.12.0"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5feca120d06492f750cab79c22fb60b8857f96adbe2c87637cdd3c44198e90"
 dependencies = [
- "audionimbus-sys 4.8.1",
+ "audionimbus-sys",
  "bitflags 2.11.0",
  "slotmap",
-]
-
-[[package]]
-name = "audionimbus-sys"
-version = "4.8.1"
-dependencies = [
- "bindgen",
- "zip",
 ]
 
 [[package]]
@@ -356,6 +350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111aaefa0bd5af1de99eae6baff76fd3a98bee1d458fc23cc6c3da4a284e8722"
 dependencies = [
  "bindgen",
+ "zip",
 ]
 
 [[package]]
@@ -1534,7 +1529,7 @@ name = "bevy_steam_audio"
 version = "0.3.0-rc.1"
 dependencies = [
  "audionimbus",
- "audionimbus-sys 4.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "audionimbus-sys",
  "bevy_app",
  "bevy_asset",
  "bevy_camera",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,8 +337,16 @@ name = "audionimbus"
 version = "0.12.0"
 dependencies = [
  "audionimbus-sys 4.8.1",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "slotmap",
+]
+
+[[package]]
+name = "audionimbus-sys"
+version = "4.8.1"
+dependencies = [
+ "bindgen",
+ "zip",
 ]
 
 [[package]]
@@ -348,14 +356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111aaefa0bd5af1de99eae6baff76fd3a98bee1d458fc23cc6c3da4a284e8722"
 dependencies = [
  "bindgen",
-]
-
-[[package]]
-name = "audionimbus-sys"
-version = "4.8.1"
-dependencies = [
- "bindgen",
- "zip",
 ]
 
 [[package]]
@@ -1534,7 +1534,7 @@ name = "bevy_steam_audio"
 version = "0.3.0-rc.1"
 dependencies = [
  "audionimbus",
- "audionimbus-sys 4.8.0",
+ "audionimbus-sys 4.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bevy_app",
  "bevy_asset",
  "bevy_camera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bevy_steam_audio = { version = "0.3.0-rc.1", path = "crates/bevy_steam_audio" }
 avian_steam_audio = { version = "0.3.0-rc.3", path = "crates/avian_steam_audio" }
 trenchbroom_steam_audio = { version = "0.3.0-rc.2", path = "crates/trenchbroom_steam_audio" }
 
-audionimbus = { path = "../audionimbus/audionimbus", default-features = false }
+audionimbus = { version = "0.13", default-features = false }
 audionimbus-sys = { version = "4.8",  default-features = false }
 
 bevy_seedling = { version = "0.7", default-features = false, features = ["reflect"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bevy_steam_audio = { version = "0.3.0-rc.1", path = "crates/bevy_steam_audio" }
 avian_steam_audio = { version = "0.3.0-rc.3", path = "crates/avian_steam_audio" }
 trenchbroom_steam_audio = { version = "0.3.0-rc.2", path = "crates/trenchbroom_steam_audio" }
 
-audionimbus = { version = "0.11", default-features = false }
+audionimbus = { path = "../audionimbus/audionimbus", default-features = false }
 audionimbus-sys = { version = "4.8",  default-features = false }
 
 bevy_seedling = { version = "0.7", default-features = false, features = ["reflect"] }

--- a/crates/avian_steam_audio/src/lib.rs
+++ b/crates/avian_steam_audio/src/lib.rs
@@ -120,7 +120,9 @@ fn add_collider(
 }
 
 #[derive(Resource, Default, Deref, DerefMut)]
-struct ShapeToScene(HashMap<ColliderKey, audionimbus::Scene>);
+struct ShapeToScene(
+    HashMap<ColliderKey, audionimbus::Scene<'static, audionimbus::DefaultRayTracer>>,
+);
 
 #[derive(Deref, DerefMut)]
 struct ColliderKey(Weak<dyn Shape>);
@@ -186,10 +188,7 @@ fn spawn_new_steam_audio_meshes(
             let sub_scene = if let Some(sub_scene) = map.get(&ColliderKey::from(collider)) {
                 sub_scene.clone()
             } else {
-                let mut sub_scene = match audionimbus::Scene::try_new(
-                    &STEAM_AUDIO_CONTEXT,
-                    &audionimbus::SceneSettings::default(),
-                ) {
+                let mut sub_scene = match audionimbus::Scene::try_new(&STEAM_AUDIO_CONTEXT) {
                     Ok(sub_scene) => sub_scene,
                     Err(err) => {
                         errors.push(format!(
@@ -230,11 +229,11 @@ fn spawn_new_steam_audio_meshes(
             let transform = transform.to_steam_audio_transform();
 
             let instanced_mesh_settings = audionimbus::InstancedMeshSettings {
-                sub_scene: sub_scene.clone(),
+                sub_scene: &sub_scene,
                 transform,
             };
             let instanced_mesh =
-                match audionimbus::InstancedMesh::try_new(&root, instanced_mesh_settings) {
+                match audionimbus::InstancedMesh::try_new(&root, &instanced_mesh_settings) {
                     Ok(instanced_mesh) => instanced_mesh,
                     Err(err) => {
                         errors.push(format!("{name}: Failed to create instanced mesh: {err}"));
@@ -244,10 +243,10 @@ fn spawn_new_steam_audio_meshes(
                         continue;
                     }
                 };
-            root.add_instanced_mesh(instanced_mesh.clone());
+            let handle = root.add_instanced_mesh(instanced_mesh);
             commands
                 .entity(entity)
-                .try_insert(SteamAudioInstancedMesh(instanced_mesh));
+                .try_insert(SteamAudioInstancedMesh(handle));
         } else {
             let mesh = match collider
                 .trimesh_builder()
@@ -274,10 +273,10 @@ fn spawn_new_steam_audio_meshes(
                     continue;
                 }
             };
-            root.add_static_mesh(static_mesh.clone());
+            let handle = root.add_static_mesh(static_mesh);
             commands
                 .entity(entity)
-                .try_insert(SteamAudioStaticMesh(static_mesh));
+                .try_insert(SteamAudioStaticMesh(handle));
         }
 
         commands
@@ -317,9 +316,9 @@ fn garbage_collect_meshes(mut map: ResMut<ShapeToScene>) {
 pub trait ToSteamAudioMesh {
     fn to_steam_audio_mesh(
         &self,
-        scene: &audionimbus::Scene,
+        scene: &audionimbus::Scene<'static, audionimbus::DefaultRayTracer>,
         material: audionimbus::Material,
-    ) -> Result<audionimbus::StaticMesh>;
+    ) -> Result<audionimbus::StaticMesh<audionimbus::DefaultRayTracer>>;
 }
 
 impl ToSteamAudioMesh for Trimesh {
@@ -327,7 +326,7 @@ impl ToSteamAudioMesh for Trimesh {
         &self,
         scene: &audionimbus::Scene,
         material: audionimbus::Material,
-    ) -> Result<audionimbus::StaticMesh> {
+    ) -> Result<audionimbus::StaticMesh<audionimbus::DefaultRayTracer>> {
         let vertices = self
             .vertices
             .iter()

--- a/crates/bevy_steam_audio/src/nodes/decoder.rs
+++ b/crates/bevy_steam_audio/src/nodes/decoder.rs
@@ -120,6 +120,7 @@ impl AudioNode for AmbisonicDecodeNode {
                     max_order: config.order.unwrap(),
                     speaker_layout: audionimbus::SpeakerLayout::Stereo,
                     hrtf: &hrtf,
+                    rendering: audionimbus::Rendering::Binaural,
                 },
             )
             .unwrap(),
@@ -216,7 +217,6 @@ impl AudioNodeProcessor for SteamAudioDecodeProcessor {
                 order: self.order,
                 hrtf: &self.hrtf,
                 orientation: self.params.listener_orientation.into(),
-                binaural: true,
             };
             let _effect_state = self.ambisonics_decode_effect.apply(
                 &ambisonics_decode_effect_params,
@@ -259,6 +259,7 @@ impl AudioNodeProcessor for SteamAudioDecodeProcessor {
                 max_order: self.order,
                 speaker_layout: audionimbus::SpeakerLayout::Stereo,
                 hrtf: &hrtf,
+                rendering: audionimbus::Rendering::Binaural,
             },
         )
         .unwrap();

--- a/crates/bevy_steam_audio/src/nodes/encoder.rs
+++ b/crates/bevy_steam_audio/src/nodes/encoder.rs
@@ -3,10 +3,11 @@ use crate::{
     nodes::{FixedProcessBlock, apply_volume_ramp},
     prelude::*,
     settings::SteamAudioQuality,
+    sources::AudioSourceInner,
     wrapper::{AudionimbusCoordinateSystem, ChannelPtrs, ToSteamAudioVec3 as _},
 };
 
-use audionimbus::AudioBuffer;
+use audionimbus::{AudioBuffer, effect::reflections::Convolution};
 use bevy_ecs::{entity_disabling::Disabled, lifecycle::HookContext, world::DeferredWorld};
 use bevy_seedling::{
     firewheel::diff::{Diff, Patch},
@@ -28,13 +29,13 @@ pub(super) fn plugin(app: &mut App) {
     app.register_node::<SteamAudioNode>();
     app.add_observer(reset_steam_audio_node);
 }
+
 #[derive(Diff, Patch, Debug, PartialEq, Clone, RealtimeClone, Component, Reflect)]
 #[reflect(Component)]
 pub struct SteamAudioNode {
     pub direct_gain: f32,
     pub reflection_gain: f32,
     pub pathing_gain: f32,
-
     pub previous_direct_gain: f32,
     pub previous_reflection_gain: f32,
     pub previous_pathing_gain: f32,
@@ -114,17 +115,16 @@ impl AudioNode for SteamAudioNode {
         let hrtf = config.hrtf.clone().expect("Created an `AudioNode` before the audio stream was ready. Please wait until `SteamAudioReady` is triggered.");
         SteamAudioProcessor {
             params: self.clone(),
-
             direct_effect: audionimbus::DirectEffect::try_new(
                 &STEAM_AUDIO_CONTEXT,
                 &settings,
                 &audionimbus::DirectEffectSettings { num_channels: 2 },
             )
             .unwrap(),
-            reflection_effect: audionimbus::ReflectionEffect::try_new(
+            reflection_effect: audionimbus::ReflectionEffect::<Convolution>::try_new(
                 &STEAM_AUDIO_CONTEXT,
                 &settings,
-                &audionimbus::ReflectionEffectSettings::Convolution {
+                &audionimbus::ReflectionEffectSettings {
                     impulse_response_size: config
                         .quality
                         .impulse_response_size(settings.sampling_rate),
@@ -157,6 +157,7 @@ impl AudioNode for SteamAudioNode {
                     max_order: config.quality.order,
                     speaker_layout: audionimbus::SpeakerLayout::Stereo,
                     hrtf: &hrtf,
+                    rendering: audionimbus::Rendering::Binaural,
                 },
             )
             .unwrap(),
@@ -183,12 +184,12 @@ struct SteamAudioProcessor {
     quality: SteamAudioQuality,
     params: SteamAudioNode,
     direct_effect: audionimbus::DirectEffect,
-    reflection_effect: audionimbus::ReflectionEffect,
+    reflection_effect: audionimbus::ReflectionEffect<Convolution>,
     binaural_effect: audionimbus::BinauralEffect,
     pathing_effect: audionimbus::PathEffect,
     ambisonics_decode_effect: audionimbus::AmbisonicsDecodeEffect,
     fixed_block: FixedProcessBlock,
-    source: Option<audionimbus::Source>,
+    source: Option<AudioSourceInner>,
     // We might be able to use the scratch buffers for this, but
     // the ambisonic order may produce more channels than scratch
     // buffers.
@@ -290,7 +291,9 @@ impl AudioNodeProcessor for SteamAudioProcessor {
                 )
                 .unwrap()
             };
-            mono_reflect_sa_buffer.downmix(&STEAM_AUDIO_CONTEXT, &input_sa_buffer);
+            mono_reflect_sa_buffer
+                .downmix(&STEAM_AUDIO_CONTEXT, &input_sa_buffer)
+                .unwrap();
 
             assert!(scratch_mono_pathing.len() >= frame_size);
             let mut channel_ptrs = [scratch_mono_pathing.as_mut_ptr()];
@@ -304,7 +307,9 @@ impl AudioNodeProcessor for SteamAudioProcessor {
                 )
                 .unwrap()
             };
-            mono_pathing_sa_buffer.downmix(&STEAM_AUDIO_CONTEXT, &input_sa_buffer);
+            mono_pathing_sa_buffer
+                .downmix(&STEAM_AUDIO_CONTEXT, &input_sa_buffer)
+                .unwrap();
 
             assert!(scratch_stereo_left.len() >= frame_size);
             assert!(scratch_stereo_right.len() >= frame_size);
@@ -329,6 +334,7 @@ impl AudioNodeProcessor for SteamAudioProcessor {
 
             let mut direct_effect_params = source
                 .get_outputs(audionimbus::SimulationFlags::DIRECT)
+                .unwrap()
                 .direct()
                 .into_inner();
             direct_effect_params.directivity = Some(audionimbus::directivity_attenuation(
@@ -347,12 +353,17 @@ impl AudioNodeProcessor for SteamAudioProcessor {
                 listener.origin.to_steam_audio_vec3(),
                 &audionimbus::DistanceAttenuationModel::Default,
             ));
-            direct_effect_params.air_absorption = Some(audionimbus::air_absorption(
-                &STEAM_AUDIO_CONTEXT,
-                &source_position.origin.to_steam_audio_vec3(),
-                &listener.origin.to_steam_audio_vec3(),
-                &audionimbus::AirAbsorptionModel::Default,
-            ));
+            direct_effect_params.air_absorption = Some(
+                // SAFETY: This is safe because we're not using a callback.
+                unsafe {
+                    audionimbus::air_absorption(
+                        &STEAM_AUDIO_CONTEXT,
+                        source_position.origin.to_steam_audio_vec3(),
+                        listener.origin.to_steam_audio_vec3(),
+                        &audionimbus::AirAbsorptionModel::Default,
+                    )
+                },
+            );
 
             let _effect_state = self.direct_effect.apply(
                 &direct_effect_params,
@@ -402,35 +413,41 @@ impl AudioNodeProcessor for SteamAudioProcessor {
             )
             .unwrap();
 
-            let mut reflection_effect_params = source
-                .get_outputs(audionimbus::SimulationFlags::REFLECTIONS)
-                .reflections()
-                .into_inner();
-            reflection_effect_params.reflection_effect_type = self.quality.reflections.kind.into();
-            reflection_effect_params.num_channels = self.quality.num_channels();
-            reflection_effect_params.impulse_response_size = self
-                .quality
-                .impulse_response_size(proc_info.sample_rate.into());
+            {
+                let outputs = source
+                    .get_outputs(audionimbus::SimulationFlags::REFLECTIONS)
+                    .unwrap();
+                let mut reflection_effect_params =
+                    outputs.reflections::<Convolution>().into_inner();
+                reflection_effect_params
+                    .set_num_channels(self.quality.num_channels())
+                    .unwrap();
+                reflection_effect_params
+                    .set_impulse_response_size(
+                        self.quality
+                            .impulse_response_size(proc_info.sample_rate.into()),
+                    )
+                    .unwrap();
 
-            apply_volume_ramp(
-                self.params.previous_reflection_gain,
-                self.params.reflection_gain,
-                &mut [scratch_mono_reflect],
-            );
-            self.params.previous_reflection_gain = self.params.reflection_gain;
+                apply_volume_ramp(
+                    self.params.previous_reflection_gain,
+                    self.params.reflection_gain,
+                    &mut [scratch_mono_reflect],
+                );
+                self.params.previous_reflection_gain = self.params.reflection_gain;
 
-            let _effect_state = self.reflection_effect.apply(
-                &reflection_effect_params,
-                &mono_reflect_sa_buffer,
-                &ambisonics_sa_buffer,
-            );
+                let _effect_state = self.reflection_effect.apply(
+                    &reflection_effect_params,
+                    &mono_reflect_sa_buffer,
+                    &ambisonics_sa_buffer,
+                );
+            }
 
             // Decode ambisonics
             let ambisonics_decode_effect_params = audionimbus::AmbisonicsDecodeEffectParams {
                 order: self.quality.order,
                 hrtf: &self.hrtf,
                 orientation: listener.into(),
-                binaural: true,
             };
             let _effect_state = self.ambisonics_decode_effect.apply(
                 &ambisonics_decode_effect_params,
@@ -438,17 +455,19 @@ impl AudioNodeProcessor for SteamAudioProcessor {
                 &scratch_stereo_sa_buffer,
             );
 
-            output_sa_buffer.mix(&STEAM_AUDIO_CONTEXT, &scratch_stereo_sa_buffer);
+            output_sa_buffer
+                .mix(&STEAM_AUDIO_CONTEXT, &scratch_stereo_sa_buffer)
+                .unwrap();
 
             // Pathing effect
             if self.params.pathing_available {
                 let mut pathing_effect_params = source
                     .get_outputs(audionimbus::SimulationFlags::PATHING)
+                    .unwrap()
                     .pathing()
                     .into_inner();
                 pathing_effect_params.order = self.quality.order;
                 pathing_effect_params.listener = listener.into();
-                pathing_effect_params.binaural = true;
                 pathing_effect_params.hrtf = self.hrtf.clone();
 
                 apply_volume_ramp(
@@ -462,8 +481,9 @@ impl AudioNodeProcessor for SteamAudioProcessor {
                     &mono_pathing_sa_buffer,
                     &scratch_stereo_sa_buffer,
                 );
-
-                output_sa_buffer.mix(&STEAM_AUDIO_CONTEXT, &scratch_stereo_sa_buffer);
+                output_sa_buffer
+                    .mix(&STEAM_AUDIO_CONTEXT, &scratch_stereo_sa_buffer)
+                    .unwrap();
             }
         });
 
@@ -500,10 +520,10 @@ impl AudioNodeProcessor for SteamAudioProcessor {
             &audionimbus::DirectEffectSettings { num_channels: 2 },
         )
         .unwrap();
-        self.reflection_effect = audionimbus::ReflectionEffect::try_new(
+        self.reflection_effect = audionimbus::ReflectionEffect::<Convolution>::try_new(
             &STEAM_AUDIO_CONTEXT,
             &settings,
-            &audionimbus::ReflectionEffectSettings::Convolution {
+            &audionimbus::ReflectionEffectSettings {
                 impulse_response_size: self.quality.impulse_response_size(settings.sampling_rate),
                 num_channels: self.quality.num_channels(),
             },
@@ -527,7 +547,6 @@ impl AudioNodeProcessor for SteamAudioProcessor {
             &audionimbus::BinauralEffectSettings { hrtf: &self.hrtf },
         )
         .unwrap();
-
         self.ambisonics_decode_effect = audionimbus::AmbisonicsDecodeEffect::try_new(
             &STEAM_AUDIO_CONTEXT,
             &settings,
@@ -535,6 +554,7 @@ impl AudioNodeProcessor for SteamAudioProcessor {
                 max_order: self.quality.order,
                 speaker_layout: audionimbus::SpeakerLayout::Stereo,
                 hrtf: &self.hrtf,
+                rendering: audionimbus::Rendering::Binaural,
             },
         )
         .unwrap();

--- a/crates/bevy_steam_audio/src/nodes/reverb.rs
+++ b/crates/bevy_steam_audio/src/nodes/reverb.rs
@@ -1,4 +1,4 @@
-use audionimbus::AudioBuffer;
+use audionimbus::{AudioBuffer, effect::reflections::Convolution};
 use bevy_ecs::{entity_disabling::Disabled, lifecycle::HookContext, world::DeferredWorld};
 use bevy_seedling::{node::RegisterNode as _, pool::Sampler, prelude::*};
 use firewheel::{
@@ -14,6 +14,7 @@ use firewheel::{
 use crate::{
     nodes::{FixedProcessBlock, apply_volume_ramp},
     prelude::*,
+    sources::ListenerSourceInner,
     wrapper::{AudionimbusCoordinateSystem, ChannelPtrs},
 };
 
@@ -94,10 +95,10 @@ impl AudioNode for SteamAudioReverbNode {
         };
         SteamAudioReverbNodeProcessor {
             source: None,
-            reflection_effect: audionimbus::ReflectionEffect::try_new(
+            reflection_effect: audionimbus::ReflectionEffect::<Convolution>::try_new(
                 &STEAM_AUDIO_CONTEXT,
                 &settings,
-                &audionimbus::ReflectionEffectSettings::Convolution {
+                &audionimbus::ReflectionEffectSettings {
                     impulse_response_size: config
                         .quality
                         .impulse_response_size(cx.stream_info.sample_rate.into()),
@@ -124,9 +125,10 @@ impl AudioNode for SteamAudioReverbNode {
                 &STEAM_AUDIO_CONTEXT,
                 &settings,
                 &audionimbus::AmbisonicsDecodeEffectSettings {
-                    max_order: config.quality.order,
                     speaker_layout: audionimbus::SpeakerLayout::Stereo,
                     hrtf: &hrtf,
+                    max_order: config.quality.order,
+                    rendering: audionimbus::Rendering::Binaural,
                 },
             )
             .unwrap(),
@@ -138,8 +140,8 @@ struct SteamAudioReverbNodeProcessor {
     quality: SteamAudioQuality,
     hrtf: audionimbus::Hrtf,
     params: SteamAudioReverbNode,
-    source: Option<audionimbus::Source>,
-    reflection_effect: audionimbus::ReflectionEffect,
+    source: Option<ListenerSourceInner>,
+    reflection_effect: audionimbus::ReflectionEffect<Convolution>,
     ambisonics_decode_effect: audionimbus::AmbisonicsDecodeEffect,
     // We might be able to use the scratch buffers for this, but
     // the ambisonic order may produce more channels than scratch
@@ -182,10 +184,11 @@ impl AudioNodeProcessor for SteamAudioReverbNodeProcessor {
             return ProcessStatus::ClearAllOutputs;
         };
 
-        let mut reflection_effect_params = source
+        let reflection_outputs = source
             .get_outputs(audionimbus::SimulationFlags::REFLECTIONS)
-            .reflections()
-            .into_inner();
+            .unwrap();
+        let mut reflection_effect_params =
+            reflection_outputs.reflections::<Convolution>().into_inner();
 
         let scratch_mono = extra.scratch_buffers.first_mut();
         let frame_size = self.fixed_block.frame_size();
@@ -237,13 +240,19 @@ impl AudioNodeProcessor for SteamAudioReverbNodeProcessor {
                 )
                 .unwrap()
             };
-            mono_sa_buffer.downmix(&STEAM_AUDIO_CONTEXT, &input_sa_buffer);
+            mono_sa_buffer
+                .downmix(&STEAM_AUDIO_CONTEXT, &input_sa_buffer)
+                .unwrap();
 
-            reflection_effect_params.reflection_effect_type = self.quality.reflections.kind.into();
-            reflection_effect_params.num_channels = self.quality.num_channels();
-            reflection_effect_params.impulse_response_size = self
-                .quality
-                .impulse_response_size(proc_info.sample_rate.into());
+            reflection_effect_params
+                .set_num_channels(self.quality.num_channels())
+                .unwrap();
+            reflection_effect_params
+                .set_impulse_response_size(
+                    self.quality
+                        .impulse_response_size(proc_info.sample_rate.into()),
+                )
+                .unwrap();
 
             apply_volume_ramp(
                 self.params.previous_gain,
@@ -274,7 +283,6 @@ impl AudioNodeProcessor for SteamAudioReverbNodeProcessor {
                 order: self.quality.order,
                 hrtf: &self.hrtf,
                 orientation: listener.into(),
-                binaural: true,
             };
             let _effect_state = self.ambisonics_decode_effect.apply(
                 &decode_params,
@@ -308,10 +316,10 @@ impl AudioNodeProcessor for SteamAudioReverbNodeProcessor {
             sampling_rate: stream_info.sample_rate.get(),
             frame_size: self.quality.frame_size,
         };
-        self.reflection_effect = audionimbus::ReflectionEffect::try_new(
+        self.reflection_effect = audionimbus::ReflectionEffect::<Convolution>::try_new(
             &STEAM_AUDIO_CONTEXT,
             &settings,
-            &audionimbus::ReflectionEffectSettings::Convolution {
+            &audionimbus::ReflectionEffectSettings {
                 impulse_response_size: self
                     .quality
                     .impulse_response_size(stream_info.sample_rate.into()),
@@ -326,8 +334,13 @@ impl AudioNodeProcessor for SteamAudioReverbNodeProcessor {
                 max_order: self.quality.order,
                 speaker_layout: audionimbus::SpeakerLayout::Stereo,
                 hrtf: &self.hrtf,
+                rendering: audionimbus::Rendering::Binaural,
             },
         )
         .unwrap();
+
+        let fixed_block_size = self.fixed_block.inputs.channel_capacity;
+        let max_output_size = stream_info.max_block_frames.get() as usize;
+        self.fixed_block.resize(fixed_block_size, max_output_size);
     }
 }

--- a/crates/bevy_steam_audio/src/probes.rs
+++ b/crates/bevy_steam_audio/src/probes.rs
@@ -83,7 +83,7 @@ fn generate_probes(
         transform,
     };
     let mut array = audionimbus::ProbeArray::try_new(&STEAM_AUDIO_CONTEXT)?;
-    array.generate_probes(&root, &params);
+    array.generate_probes(&root.0, &params);
     if array.num_probes() == 0 {
         error!("Failed to generate any probes. Is the scene empty?");
         return Ok(());
@@ -95,15 +95,14 @@ fn generate_probes(
     batch.commit();
 
     if let Some(old_batch) = probe_batch.as_ref() {
-        simulator.remove_probe_batch(old_batch);
+        simulator.remove_probe_batch(&old_batch.0);
     }
     simulator.add_probe_batch(&batch);
     simulator.commit();
 
+    let baker = audionimbus::PathBaker::<audionimbus::DefaultRayTracer>::new();
     let bake_params = audionimbus::PathBakeParams {
-        scene: &root,
-        probe_batch: &batch,
-        identifier: &audionimbus::BakedDataIdentifier::Pathing {
+        identifier: audionimbus::BakedDataIdentifier::Pathing {
             variation: audionimbus::BakedDataVariation::Dynamic,
         },
         num_samples: quality.pathing.num_visibility_samples,
@@ -113,20 +112,19 @@ fn generate_probes(
         visibility_range: pathing_settings.visibility_range,
         num_threads: 4,
     };
-    audionimbus::bake_path(
+
+    if let Err(e) = baker.bake_with_progress_callback(
         &STEAM_AUDIO_CONTEXT,
-        &bake_params,
-        Some(audionimbus::CallbackInformation {
-            callback: progress_callback,
-            user_data: std::ptr::null_mut(),
+        &mut batch,
+        &root.0,
+        bake_params,
+        audionimbus::ProgressCallback::new(|progress| {
+            debug!("Pathing bake progress: {:.2}%", progress * 100.0);
         }),
-    );
+    ) {
+        error!("Path bake failed: {e:?}");
+    }
 
     commands.insert_resource(SteamAudioProbeBatch(batch));
-
     Ok(())
-}
-
-unsafe extern "C" fn progress_callback(progress: f32, _user_data: *mut std::ffi::c_void) {
-    debug!("Pathing progress: {:.2}%", progress * 100.0);
 }

--- a/crates/bevy_steam_audio/src/scene/mesh_backend.rs
+++ b/crates/bevy_steam_audio/src/scene/mesh_backend.rs
@@ -42,7 +42,9 @@ impl Plugin for Mesh3dSteamAudioScenePlugin {
 }
 
 #[derive(Resource, Default, Deref, DerefMut)]
-struct MeshToScene(HashMap<AssetId<Mesh>, audionimbus::Scene>);
+struct MeshToScene(
+    HashMap<AssetId<Mesh>, audionimbus::Scene<'static, audionimbus::DefaultRayTracer>>,
+);
 
 fn queue_steam_audio_mesh_processing(
     meshes: Query<(Entity, Ref<Mesh3d>), With<SteamAudioMaterial>>,
@@ -84,13 +86,10 @@ fn spawn_new_steam_audio_meshes(
         };
 
         if !is_static {
-            let sub_scene = if let Some(sub_scene) = map.get(&id) {
+            let sub_scene = if let Some(sub_scene) = map.0.get(&id) {
                 sub_scene.clone()
             } else {
-                let mut sub_scene = match audionimbus::Scene::try_new(
-                    &STEAM_AUDIO_CONTEXT,
-                    &audionimbus::SceneSettings::default(),
-                ) {
+                let mut sub_scene = match audionimbus::Scene::try_new(&STEAM_AUDIO_CONTEXT) {
                     Ok(sub_scene) => sub_scene,
                     Err(err) => {
                         errors.push(format!(
@@ -115,17 +114,16 @@ fn spawn_new_steam_audio_meshes(
                 sub_scene.add_static_mesh(static_mesh);
                 // committing a new scene should be fine during simulation of a different scene
                 sub_scene.commit();
-                map.insert(id, sub_scene.clone());
+                map.0.insert(id, sub_scene.clone());
                 sub_scene
             };
-            let transform = transform.to_steam_audio_transform();
 
             let instanced_mesh_settings = audionimbus::InstancedMeshSettings {
-                sub_scene: sub_scene.clone(),
-                transform,
+                sub_scene: &sub_scene,
+                transform: transform.to_steam_audio_transform(),
             };
             let instanced_mesh =
-                match audionimbus::InstancedMesh::try_new(&root, instanced_mesh_settings) {
+                match audionimbus::InstancedMesh::try_new(&root.0, &instanced_mesh_settings) {
                     Ok(instanced_mesh) => instanced_mesh,
                     Err(err) => {
                         errors.push(format!("{name}: Failed to create instanced mesh: {err}"));
@@ -135,13 +133,13 @@ fn spawn_new_steam_audio_meshes(
                         continue;
                     }
                 };
-            root.add_instanced_mesh(instanced_mesh.clone());
+            let handle = root.0.add_instanced_mesh(instanced_mesh);
             commands
                 .entity(entity)
-                .try_insert(SteamAudioInstancedMesh(instanced_mesh));
+                .try_insert(SteamAudioInstancedMesh(handle));
         } else {
             let mesh = mesh.clone().transformed_by(transform.compute_transform());
-            let static_mesh = match mesh.to_steam_audio_mesh(&root, (*material).into()) {
+            let static_mesh = match mesh.to_steam_audio_mesh(&root.0, (*material).into()) {
                 Ok(mesh) => mesh,
                 Err(err) => {
                     errors.push(format!("{name}: Failed to convert mesh: {err}"));
@@ -151,10 +149,10 @@ fn spawn_new_steam_audio_meshes(
                     continue;
                 }
             };
-            root.add_static_mesh(static_mesh.clone());
+            let handle = root.0.add_static_mesh(static_mesh);
             commands
                 .entity(entity)
-                .try_insert(SteamAudioStaticMesh(static_mesh));
+                .try_insert(SteamAudioStaticMesh(handle));
         }
 
         commands
@@ -170,12 +168,9 @@ fn spawn_new_steam_audio_meshes(
                     continue;
                 }
             };
-
             commands.entity(entity).try_insert(gizmo);
         }
     }
-    // Do not call root.commit(), it's not safe while simulations are running
-
     if !errors.is_empty() {
         Err(errors.join("\n").into())
     } else {
@@ -189,7 +184,7 @@ fn garbage_collect_meshes(
 ) {
     for event in asset_events.read() {
         if let AssetEvent::Removed { id } | AssetEvent::Modified { id } = event {
-            map.remove(id);
+            map.0.remove(id);
         }
     }
 }

--- a/crates/bevy_steam_audio/src/scene/mod.rs
+++ b/crates/bevy_steam_audio/src/scene/mod.rs
@@ -16,15 +16,11 @@ pub(super) fn plugin(app: &mut App) {
 }
 
 #[derive(Resource, Deref, DerefMut)]
-pub struct SteamAudioRootScene(pub audionimbus::Scene);
+pub struct SteamAudioRootScene(pub audionimbus::Scene<'static, audionimbus::DefaultRayTracer>);
 
 impl Default for SteamAudioRootScene {
     fn default() -> Self {
-        let mut scene = audionimbus::Scene::try_new(
-            &STEAM_AUDIO_CONTEXT,
-            &audionimbus::SceneSettings::default(),
-        )
-        .unwrap();
+        let mut scene = audionimbus::Scene::try_new(&STEAM_AUDIO_CONTEXT).unwrap();
         scene.commit();
         Self(scene)
     }
@@ -34,11 +30,13 @@ impl Default for SteamAudioRootScene {
 #[reflect(Component)]
 pub struct Static;
 
+/// Stores the handle returned by `Scene::add_instanced_mesh`.
 #[derive(Component)]
-pub struct SteamAudioInstancedMesh(pub audionimbus::InstancedMesh);
+pub struct SteamAudioInstancedMesh(pub audionimbus::InstancedMeshHandle);
 
+/// Stores the handle returned by `Scene::add_static_mesh`.
 #[derive(Component)]
-pub struct SteamAudioStaticMesh(pub audionimbus::StaticMesh);
+pub struct SteamAudioStaticMesh(pub audionimbus::StaticMeshHandle);
 
 fn remove_material(remove: On<Remove, SteamAudioMaterial>, mut commands: Commands) {
     commands
@@ -52,9 +50,8 @@ fn remove_dynamic_mesh_from_scene(
     instanced_mesh: Query<&SteamAudioInstancedMesh, Allow<Disabled>>,
     mut root: ResMut<SteamAudioRootScene>,
 ) -> Result {
-    let instanced_mesh = instanced_mesh.get(remove.entity)?;
-    // replace runs *before* the actual replace, so let's remove the *old* mesh
-    root.remove_instanced_mesh(&instanced_mesh.0);
+    let handle = instanced_mesh.get(remove.entity)?;
+    root.0.remove_instanced_mesh(handle.0);
     Ok(())
 }
 
@@ -63,9 +60,8 @@ fn remove_static_mesh_from_scene(
     static_mesh: Query<&SteamAudioStaticMesh, Allow<Disabled>>,
     mut root: ResMut<SteamAudioRootScene>,
 ) -> Result {
-    let static_mesh = static_mesh.get(remove.entity)?;
-    // replace runs *before* the actual replace, so let's remove the *old* mesh
-    root.remove_static_mesh(&static_mesh.0);
+    let handle = static_mesh.get(remove.entity)?;
+    root.0.remove_static_mesh(handle.0);
     Ok(())
 }
 
@@ -73,13 +69,12 @@ fn update_transforms(
     transforms: Query<(Ref<GlobalTransform>, &SteamAudioInstancedMesh)>,
     mut root: ResMut<SteamAudioRootScene>,
 ) {
-    for (transform, instanced_mesh) in transforms.iter() {
+    for (transform, handle) in transforms.iter() {
         if !transform.is_changed() {
             continue;
         }
         let transform = transform.to_steam_audio_transform();
-
-        root.update_instanced_mesh_transform(&instanced_mesh.0, transform);
+        root.0.update_instanced_mesh_transform(handle.0, transform);
     }
 }
 

--- a/crates/bevy_steam_audio/src/settings.rs
+++ b/crates/bevy_steam_audio/src/settings.rs
@@ -114,18 +114,8 @@ pub enum SteamAudioReflectionKind {
     Hybrid,
 }
 
-impl From<SteamAudioReflectionKind> for audionimbus::ReflectionEffectType {
-    fn from(kind: SteamAudioReflectionKind) -> Self {
-        match kind {
-            SteamAudioReflectionKind::Convolution => audionimbus::ReflectionEffectType::Convolution,
-            SteamAudioReflectionKind::Parametric => audionimbus::ReflectionEffectType::Parametric,
-            SteamAudioReflectionKind::Hybrid => audionimbus::ReflectionEffectType::Hybrid,
-        }
-    }
-}
-
 impl SteamAudioReflectionsQuality {
-    pub(crate) fn to_audionimbus(self) -> audionimbus::ReflectionsSimulationSettings<'static> {
+    pub(crate) fn to_audionimbus(&self) -> audionimbus::ReflectionsSimulationSettings<'static> {
         match self.kind {
             SteamAudioReflectionKind::Convolution => {
                 audionimbus::ReflectionsSimulationSettings::Convolution {
@@ -180,16 +170,16 @@ impl SteamAudioQuality {
     pub(crate) fn to_audionimbus_simulation_shared_inputs(
         self,
         listener_position: AudionimbusCoordinateSystem,
-    ) -> audionimbus::SimulationSharedInputs {
-        audionimbus::SimulationSharedInputs {
-            num_rays: self.reflections.num_rays,
-            num_bounces: self.num_bounces,
-            duration: self.reflections.impulse_duration.as_secs_f32(),
-            irradiance_min_distance: self.irradiance_min_distance,
-            listener: listener_position.into(),
-            order: self.order,
-            pathing_visualization_callback: None,
-        }
+    ) -> audionimbus::SimulationSharedInputs<(), audionimbus::Reflections, ()> {
+        audionimbus::SimulationSharedInputs::new(listener_position.into()).with_reflections(
+            audionimbus::ReflectionsSharedInputs {
+                num_rays: self.reflections.num_rays,
+                num_bounces: self.num_bounces,
+                duration: self.reflections.impulse_duration.as_secs_f32(),
+                order: self.order,
+                irradiance_min_distance: self.irradiance_min_distance,
+            },
+        )
     }
 
     pub(crate) fn impulse_response_size(self, sampling_rate: u32) -> u32 {

--- a/crates/bevy_steam_audio/src/simulation.rs
+++ b/crates/bevy_steam_audio/src/simulation.rs
@@ -18,7 +18,7 @@ use crate::{
     settings::{
         SteamAudioEnabled, SteamAudioHrtf, SteamAudioPathBakingSettings, SteamAudioQuality,
     },
-    sources::{AudionimbusSource, ListenerSource, SourcesToRemove},
+    sources::{AudionimbusSource, ListenerSource, ListenerSourceInner, SourcesToRemove},
 };
 
 use bevy_seedling::{
@@ -31,7 +31,7 @@ use crate::wrapper::*;
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(
         PostUpdate,
-        (recreate_simulator_on_settings_change)
+        recreate_simulator_on_settings_change
             .in_set(SteamAudioSystems::CreateSimulator)
             .run_if(resource_exists::<AudionimbusSimulator>),
     );
@@ -58,35 +58,29 @@ struct AsyncSimulationSynchronization {
     complete: Arc<AtomicBool>,
 }
 
+type InnerSimulator = audionimbus::Simulator<
+    'static,
+    audionimbus::DefaultRayTracer,
+    audionimbus::Direct,
+    audionimbus::Reflections,
+    audionimbus::Pathing,
+>;
+
 #[derive(Resource)]
 pub struct AudionimbusSimulator {
-    simulator: Arc<
-        RwLock<
-            audionimbus::Simulator<
-                audionimbus::Direct,
-                audionimbus::Reflections,
-                audionimbus::Pathing,
-            >,
-        >,
-    >,
+    simulator: Arc<RwLock<InnerSimulator>>,
     pub sampling_rate: NonZeroU32,
+    /// A permanently empty probe batch used as a placeholder for `set_inputs` calls when no real
+    /// probes have been generated yet.
+    fallback_probe_batch: audionimbus::ProbeBatch,
 }
+
 impl AudionimbusSimulator {
     /// Used to force consumers to only ever use `ResMut` and not `Res`,
     /// as running two things simultaneously on the underlying Steam Audio simulator
     /// needs to be carefully managed, even when using `.read()`. E.g. it's easy to accidentally
     /// have two systems adding a source to the same simulator in parallel if this was used with `Res`.
-    pub fn get(
-        &mut self,
-    ) -> &Arc<
-        RwLock<
-            audionimbus::Simulator<
-                audionimbus::Direct,
-                audionimbus::Reflections,
-                audionimbus::Pathing,
-            >,
-        >,
-    > {
+    pub fn get(&mut self) -> &Arc<RwLock<InnerSimulator>> {
         &self.simulator
     }
 }
@@ -156,56 +150,62 @@ fn create_simulator(
         },
     )
     .unwrap();
+
     for mut node_config in nodes.iter_mut() {
         *node_config = SteamAudioNodeConfig {
             quality: *quality,
             hrtf: Some(hrtf.clone()),
-        }
+        };
     }
     for mut reverb_node_config in reverb_nodes.iter_mut() {
         *reverb_node_config = SteamAudioReverbNodeConfig {
             quality: *quality,
             hrtf: Some(hrtf.clone()),
-        }
+        };
     }
     commands.insert_resource(SteamAudioHrtf(hrtf));
     // All sources to be removed are already removed by despawning the old simulator
     commands.insert_resource(SourcesToRemove::default());
 
-    let mut simulator = audionimbus::Simulator::builder(
-        audionimbus::SceneParams::Default,
+    let simulator_settings = audionimbus::SimulationSettings::new(
         create.sampling_rate.into(),
         quality.frame_size,
         quality.order,
     )
     .with_direct(quality.direct.into())
     .with_reflections(quality.reflections.to_audionimbus())
-    .with_pathing(quality.pathing.into())
-    .try_build(&STEAM_AUDIO_CONTEXT)?;
-    simulator.set_scene(&root);
+    .with_pathing(quality.pathing.into());
 
-    let listener_source = audionimbus::Source::try_new(
+    let mut simulator = audionimbus::Simulator::try_new(&STEAM_AUDIO_CONTEXT, &simulator_settings)?;
+    simulator.set_scene(&root.0);
+
+    let listener_source: ListenerSourceInner = audionimbus::Source::try_new(
         &simulator,
         &audionimbus::SourceSettings {
-            flags: audionimbus::SimulationFlags::REFLECTIONS,
+            flags: audionimbus::SimulationFlags::REFLECTIONS
+                | audionimbus::SimulationFlags::PATHING,
         },
     )?;
     simulator.add_source(&listener_source);
 
     for source in &sources {
-        simulator.add_source(source);
+        simulator.add_source(&source.0);
     }
     if let Some(probe_batch) = probe_batch {
-        simulator.add_probe_batch(&probe_batch);
+        simulator.add_probe_batch(&probe_batch.0);
     }
 
     simulator.commit();
 
-    let simulator = Arc::new(RwLock::new(simulator.clone()));
+    // Empty fallback batch
+    let fallback_probe_batch = audionimbus::ProbeBatch::try_new(&STEAM_AUDIO_CONTEXT)?;
+
+    let simulator_arc = Arc::new(RwLock::new(simulator));
     commands.insert_resource(ListenerSource(listener_source));
     commands.insert_resource(AudionimbusSimulator {
-        simulator: simulator.clone(),
+        simulator: simulator_arc.clone(),
         sampling_rate: create.sampling_rate,
+        fallback_probe_batch,
     });
 
     let simulation_complete = Arc::new(AtomicBool::new(false));
@@ -220,9 +220,9 @@ fn create_simulator(
         loop {
             {
                 // Block thread until simulator is ready
-                let simulator = simulator.read().unwrap();
-                simulator.run_reflections();
-                simulator.run_pathing();
+                let simulator = simulator_arc.read().unwrap();
+                let _ = simulator.run_reflections();
+                let _ = simulator.run_pathing();
             }
 
             simulation_complete_inner.store(true, Ordering::Relaxed);
@@ -238,9 +238,48 @@ fn create_simulator(
     Ok(())
 }
 
+/// Builds the direct simulation parameters used for every audio source.
+fn source_direct_params(quality: &SteamAudioQuality) -> audionimbus::DirectSimulationParameters {
+    audionimbus::DirectSimulationParameters::new()
+        .with_distance_attenuation(audionimbus::DistanceAttenuationModel::Default)
+        .with_air_absorption(audionimbus::AirAbsorptionModel::Default)
+        .with_directivity(audionimbus::Directivity::WeightedDipole {
+            // TODO: synchronize with the encoder node
+            weight: 0.0,
+            power: 0.0,
+        })
+        .with_occlusion(
+            audionimbus::Occlusion::new(audionimbus::OcclusionAlgorithm::Volumetric {
+                radius: 0.3,
+                num_occlusion_samples: quality.direct.max_num_occlusion_samples,
+            })
+            .with_transmission(audionimbus::TransmissionParameters {
+                num_transmission_rays: 16,
+            }),
+        )
+}
+
+/// Builds the pathing parameters for a source, borrowing `probe_batch` for the call duration.
+fn source_pathing_params<'a>(
+    probe_batch: &'a audionimbus::ProbeBatch,
+    pathing_settings: &SteamAudioPathBakingSettings,
+    quality: &SteamAudioQuality,
+) -> audionimbus::PathingSimulationParameters<'a> {
+    audionimbus::PathingSimulationParameters {
+        pathing_probes: probe_batch,
+        visibility_radius: pathing_settings.visibility_radius,
+        visibility_threshold: pathing_settings.visibility_threshold,
+        visibility_range: pathing_settings.visibility_range,
+        pathing_order: quality.order,
+        enable_validation: true,
+        find_alternate_paths: true,
+        deviation: audionimbus::DeviationModel::Default,
+    }
+}
+
 /// Inspired by the Unity Steam Audio plugin.
 fn update_simulation(
-    mut simulator: ResMut<AudionimbusSimulator>,
+    simulator: ResMut<AudionimbusSimulator>,
     quality: Res<SteamAudioQuality>,
     mut enabled: ResMut<SteamAudioEnabled>,
     listener: Single<&GlobalTransform, With<SteamAudioListener>>,
@@ -250,7 +289,6 @@ fn update_simulation(
     mut nodes: Query<(&mut AudionimbusSource, &GlobalTransform, &SampleEffects)>,
     mut steam_audio_nodes: Query<&mut SteamAudioNode>,
     mut reverb_node: Single<&mut SteamAudioReverbNode, Without<EffectOf>>,
-
     pathing_settings: Res<SteamAudioPathBakingSettings>,
     probes: Option<Res<SteamAudioProbeBatch>>,
     time: Res<Time>,
@@ -261,85 +299,50 @@ fn update_simulation(
     }
     errors.clear();
     let listener_transform = listener.compute_transform();
-    let listener_orientation = listener_transform.into();
+    let listener_orientation: AudionimbusCoordinateSystem = listener_transform.into();
     let shared_inputs = quality.to_audionimbus_simulation_shared_inputs(listener_orientation);
 
+    let simulator_arc = simulator.simulator.clone();
+    let pathing_available = probes.is_some();
+    let probe_batch_ref: &audionimbus::ProbeBatch = match probes.as_ref() {
+        Some(p) => &p.0,
+        None => &simulator.fallback_probe_batch,
+    };
+
     if synchro.complete.load(Ordering::SeqCst) {
-        root.commit();
+        root.0.commit();
         // This should never fail unless there's a bug, as this branch should only be called when the reflection thread is idle.
-        simulator
-            .get()
+        simulator_arc
             .try_write()
             .map_err(|e| format!("Failed to commit simulator even though it should be idle: {e}"))?
             .commit();
     }
 
-    let listener_inputs = audionimbus::SimulationInputs {
-        source: listener_orientation.into(),
-        direct_simulation: None,
-        reflections_simulation: Some(audionimbus::ReflectionsSimulationParameters::Convolution {
-            baked_data_identifier: None,
-        }),
-        pathing_simulation: probes.as_ref().map(|probes| {
-            audionimbus::PathingSimulationParameters {
-                pathing_probes: probes,
-                visibility_radius: pathing_settings.visibility_radius,
-                visibility_threshold: pathing_settings.visibility_threshold,
-                visibility_range: pathing_settings.visibility_range,
-                pathing_order: quality.order,
-                enable_validation: true,
-                find_alternate_paths: true,
-                deviation: audionimbus::DeviationModel::Default,
-            }
-        }),
-    };
-    // TODO: make this configurable
-    let source_inputs = |orientation: AudionimbusCoordinateSystem| audionimbus::SimulationInputs {
-        source: orientation.into(),
-        direct_simulation: Some(audionimbus::DirectSimulationParameters {
-            distance_attenuation: Some(audionimbus::DistanceAttenuationModel::Default),
-            air_absorption: Some(audionimbus::AirAbsorptionModel::Default),
-            directivity: Some(audionimbus::Directivity::WeightedDipole {
-                // TODO: make sure this is synchronized with the encoder. Right now they both happen to hardcode the same values.
-                weight: 0.0,
-                power: 0.0,
-            }),
-            occlusion: Some(audionimbus::Occlusion {
-                transmission: Some(audionimbus::TransmissionParameters {
-                    num_transmission_rays: 16,
-                }),
-                algorithm: audionimbus::OcclusionAlgorithm::Volumetric {
-                    radius: 0.3,
-                    num_occlusion_samples: quality.direct.max_num_occlusion_samples,
-                },
-            }),
-        }),
-        reflections_simulation: Some(audionimbus::ReflectionsSimulationParameters::Convolution {
-            baked_data_identifier: None,
-        }),
-        pathing_simulation: probes.as_ref().map(|probes| {
-            audionimbus::PathingSimulationParameters {
-                pathing_probes: probes,
-                visibility_radius: pathing_settings.visibility_radius,
-                visibility_threshold: pathing_settings.visibility_threshold,
-                visibility_range: pathing_settings.visibility_range,
-                pathing_order: quality.order,
-                enable_validation: true,
-                find_alternate_paths: true,
-                deviation: audionimbus::DeviationModel::Default,
-            }
-        }),
+    let reflections_params = audionimbus::ReflectionsSimulationParameters::Convolution {
+        baked_data_identifier: None,
     };
 
-    // set inputs
+    // Per-source inputs
+
     for (mut source, transform, effects) in nodes.iter_mut() {
-        let transform = transform.compute_transform();
-        let orientation = transform.into();
+        let orientation: AudionimbusCoordinateSystem = transform.compute_transform().into();
 
-        source.set_inputs(
-            audionimbus::SimulationFlags::DIRECT,
-            source_inputs(orientation),
-        );
+        let inputs = audionimbus::SimulationInputs::new(orientation.into())
+            .with_direct(source_direct_params(&quality))
+            .with_reflections(reflections_params)
+            .with_pathing(source_pathing_params(
+                probe_batch_ref,
+                &pathing_settings,
+                &quality,
+            ));
+
+        if let Err(e) = source
+            .0
+            .set_inputs(audionimbus::SimulationFlags::DIRECT, inputs)
+        {
+            errors.push(format!("Failed to set source direct inputs: {e}"));
+            continue;
+        }
 
         let mut node = match steam_audio_nodes.get_effect_mut(effects) {
             Ok(node) => node,
@@ -352,17 +355,37 @@ fn update_simulation(
         node.listener_position = listener_orientation;
     }
 
-    listener_source.set_inputs(audionimbus::SimulationFlags::DIRECT, listener_inputs);
+    {
+        let inputs = audionimbus::SimulationInputs::new(listener_orientation.into())
+            .with_direct(source_direct_params(&quality))
+            .with_reflections(reflections_params)
+            .with_pathing(source_pathing_params(
+                probe_batch_ref,
+                &pathing_settings,
+                &quality,
+            ));
+
+        if let Err(e) = listener_source.0.set_inputs(
+            audionimbus::SimulationFlags::REFLECTIONS | audionimbus::SimulationFlags::PATHING,
+            inputs,
+        ) {
+            errors.push(format!("Failed to set listener source inputs: {e}"));
+        }
+    }
+
     reverb_node.listener_position = listener_orientation;
 
-    let simulator = simulator
-        .get()
+    let simulator_read = simulator_arc
         .try_read()
         .map_err(|e| format!("Failed to run simulator even though it should be idle: {e}"))?;
 
-    simulator.set_shared_inputs(audionimbus::SimulationFlags::DIRECT, &shared_inputs);
+    if let Err(e) =
+        simulator_read.set_shared_inputs(audionimbus::SimulationFlags::DIRECT, &shared_inputs)
+    {
+        errors.push(format!("Failed to set shared direct inputs: {e}"));
+    }
 
-    simulator.run_direct();
+    simulator_read.run_direct();
 
     let Some(timer) = enabled.reflection_and_pathing_simulation_timer.as_mut() else {
         // User doesn't want any reflection or pathing simulation
@@ -390,24 +413,57 @@ fn update_simulation(
     // The previous simulation is complete, so we can start the next one
 
     // set new inputs
-    simulator.set_shared_inputs(
+    if let Err(e) = simulator_read.set_shared_inputs(
         audionimbus::SimulationFlags::REFLECTIONS | audionimbus::SimulationFlags::PATHING,
         &shared_inputs,
-    );
+    ) {
+        errors.push(format!(
+            "Failed to set shared reflections/pathing inputs: {e}"
+        ));
+    }
 
-    listener_source.set_inputs(
-        audionimbus::SimulationFlags::REFLECTIONS | audionimbus::SimulationFlags::PATHING,
-        listener_inputs,
-    );
+    {
+        let inputs = audionimbus::SimulationInputs::new(listener_orientation.into())
+            .with_direct(source_direct_params(&quality))
+            .with_reflections(reflections_params)
+            .with_pathing(source_pathing_params(
+                probe_batch_ref,
+                &pathing_settings,
+                &quality,
+            ));
+
+        if let Err(e) = listener_source.0.set_inputs(
+            audionimbus::SimulationFlags::REFLECTIONS | audionimbus::SimulationFlags::PATHING,
+            inputs,
+        ) {
+            errors.push(format!(
+                "Failed to set listener reflections/pathing inputs: {e}"
+            ));
+        }
+    }
 
     for (mut source, transform, effects) in nodes.iter_mut() {
-        let transform = transform.compute_transform();
-        let orientation = transform.into();
+        let orientation: AudionimbusCoordinateSystem = transform.compute_transform().into();
 
-        source.set_inputs(
+        let inputs = audionimbus::SimulationInputs::new(orientation.into())
+            .with_direct(source_direct_params(&quality))
+            .with_reflections(reflections_params)
+            .with_pathing(source_pathing_params(
+                probe_batch_ref,
+                &pathing_settings,
+                &quality,
+            ));
+
+        if let Err(e) = source.0.set_inputs(
             audionimbus::SimulationFlags::REFLECTIONS | audionimbus::SimulationFlags::PATHING,
-            source_inputs(orientation),
-        );
+            inputs,
+        ) {
+            errors.push(format!(
+                "Failed to set source reflections/pathing inputs: {e}"
+            ));
+            continue;
+        }
+
         let mut node = match steam_audio_nodes.get_effect_mut(effects) {
             Ok(node) => node,
             Err(err) => {
@@ -415,7 +471,7 @@ fn update_simulation(
                 continue;
             }
         };
-        node.pathing_available = probes.is_some();
+        node.pathing_available = pathing_available;
     }
 
     synchro.complete.store(false, Ordering::SeqCst);

--- a/crates/bevy_steam_audio/src/sources.rs
+++ b/crates/bevy_steam_audio/src/sources.rs
@@ -7,6 +7,20 @@ use firewheel::{diff::EventQueue as _, event::NodeEventType};
 
 use crate::{prelude::*, simulation::AudionimbusSimulator};
 
+pub type AudioSourceInner = audionimbus::Source<
+    'static,
+    audionimbus::Direct,
+    audionimbus::Reflections,
+    audionimbus::Pathing,
+>;
+
+pub type ListenerSourceInner = audionimbus::Source<
+    'static,
+    audionimbus::Direct,
+    audionimbus::Reflections,
+    audionimbus::Pathing,
+>;
+
 pub(super) fn plugin(app: &mut App) {
     app.init_resource::<ToSetup>()
         .init_resource::<SourcesToRemove>();
@@ -26,11 +40,11 @@ pub(super) fn plugin(app: &mut App) {
 }
 
 #[derive(Resource, Deref, DerefMut)]
-pub struct ListenerSource(pub(crate) audionimbus::Source);
+pub struct ListenerSource(pub(crate) ListenerSourceInner);
 
 #[derive(Component, Deref, DerefMut)]
 #[require(Transform, GlobalTransform)]
-pub struct AudionimbusSource(pub(crate) audionimbus::Source);
+pub struct AudionimbusSource(pub(crate) AudioSourceInner);
 
 fn send_source_to_processor(
     add: On<Add, AudionimbusSource>,
@@ -39,7 +53,7 @@ fn send_source_to_processor(
 ) -> Result {
     let (source, effects) = effects.get(add.entity)?;
     let mut events = events.get_effect_mut(effects)?;
-    let source: audionimbus::Source = source.0.clone();
+    let source: AudioSourceInner = source.0.clone();
     events.push(NodeEventType::custom(Some(source)));
     Ok(())
 }
@@ -49,7 +63,7 @@ fn send_source_to_reverb_processor(
     mut events: Single<&mut AudioEvents, With<SteamAudioReverbNode>>,
 ) {
     if source.is_changed() {
-        let source: audionimbus::Source = source.0.clone();
+        let source: ListenerSourceInner = source.0.clone();
         events.push(NodeEventType::custom(Some(source)));
     }
 }
@@ -130,7 +144,7 @@ fn remove_steam_audio_source(
 }
 
 #[derive(Resource, Default, Deref, DerefMut)]
-pub(crate) struct SourcesToRemove(pub(crate) Vec<audionimbus::Source>);
+pub(crate) struct SourcesToRemove(pub(crate) Vec<AudioSourceInner>);
 
 fn drain_to_remove(
     mut to_remove: ResMut<SourcesToRemove>,

--- a/crates/bevy_steam_audio/src/wrapper/mesh.rs
+++ b/crates/bevy_steam_audio/src/wrapper/mesh.rs
@@ -10,17 +10,17 @@ pub(super) fn plugin(app: &mut App) {
 pub trait ToSteamAudioMesh {
     fn to_steam_audio_mesh(
         &self,
-        scene: &audionimbus::Scene,
+        scene: &audionimbus::Scene<'static, audionimbus::DefaultRayTracer>,
         material: audionimbus::Material,
-    ) -> Result<audionimbus::StaticMesh>;
+    ) -> Result<audionimbus::StaticMesh<audionimbus::DefaultRayTracer>>;
 }
 
 impl ToSteamAudioMesh for Mesh {
     fn to_steam_audio_mesh(
         &self,
-        scene: &audionimbus::Scene,
+        scene: &audionimbus::Scene<'static, audionimbus::DefaultRayTracer>,
         material: audionimbus::Material,
-    ) -> Result<audionimbus::StaticMesh> {
+    ) -> Result<audionimbus::StaticMesh<audionimbus::DefaultRayTracer>> {
         if self.primitive_topology() != PrimitiveTopology::TriangleList {
             return Err("Mesh is not a triangle list".into());
         }

--- a/crates/trenchbroom_steam_audio/src/lib.rs
+++ b/crates/trenchbroom_steam_audio/src/lib.rs
@@ -158,15 +158,12 @@ fn handle_scene(
                         continue;
                     }
                 };
-                root.add_static_mesh(audio_mesh.clone());
+                let handle = root.0.add_static_mesh(audio_mesh);
                 commands
                     .entity(*entity)
-                    .try_insert((SteamAudioStaticMesh(audio_mesh), material));
+                    .try_insert((SteamAudioStaticMesh(handle), material));
             } else {
-                let mut sub_scene = match audionimbus::Scene::try_new(
-                    &STEAM_AUDIO_CONTEXT,
-                    &audionimbus::SceneSettings::Default,
-                ) {
+                let mut sub_scene = match audionimbus::Scene::try_new(&STEAM_AUDIO_CONTEXT) {
                     Ok(sub_scene) => sub_scene,
                     Err(err) => {
                         errors.push(format!(
@@ -190,12 +187,12 @@ fn handle_scene(
                 let transform = transform.to_steam_audio_transform();
 
                 let instanced_mesh_settings = audionimbus::InstancedMeshSettings {
-                    sub_scene: sub_scene.clone(),
+                    sub_scene: &sub_scene,
                     transform,
                 };
                 let instanced_mesh = match audionimbus::InstancedMesh::try_new(
                     &root,
-                    instanced_mesh_settings,
+                    &instanced_mesh_settings,
                 ) {
                     Ok(instanced_mesh) => instanced_mesh,
                     Err(err) => {
@@ -203,10 +200,10 @@ fn handle_scene(
                         continue;
                     }
                 };
-                root.add_instanced_mesh(instanced_mesh.clone());
+                let handle = root.0.add_instanced_mesh(instanced_mesh);
                 commands
                     .entity(*entity)
-                    .try_insert((SteamAudioInstancedMesh(instanced_mesh), material));
+                    .try_insert((SteamAudioInstancedMesh(handle), material));
             }
 
             #[cfg(feature = "debug")]


### PR DESCRIPTION
This PR updates the three crates to compile against AudioNimbus v0.12.x.

- `Scene`, `StaticMesh`, `Simulator`, and `Source` are now generic
- Mesh handles
- `SceneSettings` removed, `Scene::try_new` now only takes a context
- `SimulationInputs`, `SimulationSharedInputs`, and `Simulator` construction moved to builder patterns
- `AmbisonicsDecodeEffectSettings`: `rendering` field replaces `binaural: bool`, `hrtf` moved from params to settings
- Path baking now goes through `PathBaker`