### PR TITLE
Seed node source/listener position when a sample starts playing

### DIFF
--- a/crates/bevy_steam_audio/src/nodes/encoder.rs
+++ b/crates/bevy_steam_audio/src/nodes/encoder.rs
@@ -26,7 +26,7 @@ use firewheel::{
 
 pub(super) fn plugin(app: &mut App) {
     app.register_node::<SteamAudioNode>();
-    app.add_observer(reset_steam_audio_node);
+    app.add_observer(init_steam_audio_node);
 }
 #[derive(Diff, Patch, Debug, PartialEq, Clone, RealtimeClone, Component, Reflect)]
 #[reflect(Component)]
@@ -78,15 +78,28 @@ fn on_add_steam_audio_node_config(mut world: DeferredWorld, ctx: HookContext) {
     config.quality = quality;
 }
 
-fn reset_steam_audio_node(
+fn init_steam_audio_node(
     add: On<Add, Sampler>,
     effects: Query<&SampleEffects, Allow<Disabled>>,
+    transforms: Query<(&Transform, Option<&ChildOf>), Allow<Disabled>>,
+    parents: Query<&GlobalTransform, Allow<Disabled>>,
+    listener: Query<&GlobalTransform, With<SteamAudioListener>>,
     mut node: Query<&mut SteamAudioNode>,
 ) {
     if let Ok(effects) = effects.get(add.entity)
         && let Ok(mut node) = node.get_effect_mut(effects)
     {
         node.reset.notify();
+        if let Ok((transform, child_of)) = transforms.get(add.entity) {
+            let source = match child_of.and_then(|child_of| parents.get(child_of.parent()).ok()) {
+                Some(parent) => parent.mul_transform(*transform),
+                None => GlobalTransform::from(*transform),
+            };
+            node.source_position = source.compute_transform().into();
+        }
+        if let Ok(listener) = listener.single() {
+            node.listener_position = listener.compute_transform().into();
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

A freshly-spawned spatial source plays its first frames as if it were at the world origin, then snaps to its real position. Because the origin sits on/near the listener, it starts at full near-volume and only drops to the correct distance-attenuated level once positioned — an audible "loud, then fades out" on distant one-shots (e.g. an impact/explosion spawned far from the listener), worst the farther the source.

Since #3 (eager spatialization), the encoder computes distance attenuation each block from `SteamAudioNode::source_position`. But a new node defaults `source_position`/`listener_position` to the origin, and they're only set by `update_simulation` once the source's `AudionimbusSource` exists — a frame or more after the sample starts playing. During that window the node attenuates against the origin (≈ on the listener → no attenuation → loud).

## Fix

Seed `source_position`/`listener_position` from the entity's `GlobalTransform` in the existing on-sample-play observer (`Add<Sampler>`), so the first audio frames use the real position. Renamed `reset_steam_audio_node` → `init_steam_audio_node`, since it now initialises position in addition to resetting effect state. Completes the eager spatialization from #3 for newly-spawned sources.

## Repro

Spawn a non-looping `SamplePlayer` + `SteamAudioPool` at a `Transform` 100+ m from the listener. Before this change it plays loud for a moment, then fades to the correct quiet level; the farther the source, the larger the jump.

## Scope notes

- Kept the `compute_transform().into()` conversion inline rather than factoring a shared helper with `update_simulation`, to keep the diff focused.
- Relies on `Add<Sampler>` firing after transform propagation — true in practice, since the sampler attaches a frame+ after spawn. Setting it earlier on `Add<AudionimbusSource>` does **not** work: that position change is delivered via the node param-diff and doesn't reach the processor before playback begins.

---

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)
